### PR TITLE
Semantically equivalent spec separation for Fulm optimisation

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -298,12 +298,12 @@ predicate void ByteV (pointer virt, u8 the_value)
   return;
 }
 
-predicate (u8) NewByteV (pointer virt)
-{
-  take B = Owned<char>(virt);
-  // assert (B == the_value);
-  return B;
-}
+// predicate (u8) NewByteV (pointer virt)
+// {
+//   take B = Owned<char>(virt);
+//   // assert (B == the_value);
+//   return B;
+// }
 
 predicate void Page (pointer vbase, boolean guard, u8 order)
 {
@@ -330,7 +330,7 @@ predicate void ZeroPage (pointer vbase, boolean guard, u8 order)
     let vbaseI = ((u64) vbase);
     // FULM_OPT
     take Bytes = each (u64 i; (vbaseI <= i) && (i < (vbaseI + length)))
-         {NewByteV(array_shift<char>(NULL, i))};
+         {RW(array_shift<char>(NULL, i))};
     assert (each (u64 i; (vbaseI <= i) && (i < (vbaseI + length)))
          {Bytes[i] == 0u8});
     return;
@@ -344,7 +344,7 @@ predicate void AllocatorPageZeroPart (pointer zero_start, u8 order)
   let length = region_length - sizeof<struct list_head>;
   // FULM_OPT
   take Bytes = each (u64 i; (start <= i) && (i < (start + length)))
-       {NewByteV(array_shift<char>(NULL, i))};
+       {RW(array_shift<char>(NULL, i))};
   assert (each (u64 i; (start <= i) && (i < (start + length)))
       {Bytes[i] == 0u8});
   return;

--- a/defs.h
+++ b/defs.h
@@ -291,10 +291,10 @@ predicate void Byte (pointer virt)
   return;
 }
 
-predicate void ByteV (pointer virt, u8 the_value)
+predicate void ByteV (pointer virt)
 {
   take B = Owned<char>(virt);
-  assert (B == the_value);
+  // assert (B == the_value);
   return;
 }
 
@@ -323,7 +323,9 @@ predicate void ZeroPage (pointer vbase, boolean guard, u8 order)
     let vbaseI = ((u64) vbase);
     // FULM_OPT
     take Bytes = each (u64 i; (vbaseI <= i) && (i < (vbaseI + length)))
-         {ByteV(array_shift<char>(NULL, i), 0u8)};
+         {ByteV(array_shift<char>(NULL, i))};
+    assert (each (u64 i; (vbaseI <= i) && (i < (vbaseI + length)))
+         {Bytes[i] == 0u8});
     return;
   }
 }
@@ -335,7 +337,9 @@ predicate void AllocatorPageZeroPart (pointer zero_start, u8 order)
   let length = region_length - sizeof<struct list_head>;
   // FULM_OPT
   take Bytes = each (u64 i; (start <= i) && (i < (start + length)))
-       {ByteV(array_shift<char>(NULL, i), 0u8)};
+       {ByteV(array_shift<char>(NULL, i))};
+  assert (each (u64 i; (start <= i) && (i < (start + length)))
+      {Bytes[i] == 0u8});
   return;
 }
 

--- a/defs.h
+++ b/defs.h
@@ -291,11 +291,18 @@ predicate void Byte (pointer virt)
   return;
 }
 
-predicate void ByteV (pointer virt)
+predicate void ByteV (pointer virt, u8 the_value)
+{
+  take B = Owned<char>(virt);
+  assert (B == the_value);
+  return;
+}
+
+predicate (u8) NewByteV (pointer virt)
 {
   take B = Owned<char>(virt);
   // assert (B == the_value);
-  return;
+  return B;
 }
 
 predicate void Page (pointer vbase, boolean guard, u8 order)
@@ -323,7 +330,7 @@ predicate void ZeroPage (pointer vbase, boolean guard, u8 order)
     let vbaseI = ((u64) vbase);
     // FULM_OPT
     take Bytes = each (u64 i; (vbaseI <= i) && (i < (vbaseI + length)))
-         {ByteV(array_shift<char>(NULL, i))};
+         {NewByteV(array_shift<char>(NULL, i))};
     assert (each (u64 i; (vbaseI <= i) && (i < (vbaseI + length)))
          {Bytes[i] == 0u8});
     return;
@@ -337,7 +344,7 @@ predicate void AllocatorPageZeroPart (pointer zero_start, u8 order)
   let length = region_length - sizeof<struct list_head>;
   // FULM_OPT
   take Bytes = each (u64 i; (start <= i) && (i < (start + length)))
-       {ByteV(array_shift<char>(NULL, i))};
+       {NewByteV(array_shift<char>(NULL, i))};
   assert (each (u64 i; (start <= i) && (i < (start + length)))
       {Bytes[i] == 0u8});
   return;

--- a/defs.h
+++ b/defs.h
@@ -315,7 +315,7 @@ predicate void Page (pointer vbase, boolean guard, u8 order)
     let vbaseI = (u64) vbase;
     // FULM_OPT
     take Bytes = each (u64 i; (vbaseI <= i) && (i < (vbaseI + length)))
-         {Byte(array_shift<char>(NULL, i))};
+         {Block(array_shift<char>(NULL, i))};
     return;
   }
 }

--- a/run.sh
+++ b/run.sh
@@ -10,5 +10,8 @@ $CC -g -c -O0 -std=gnu11 -I$OPAM_SWITCH_PREFIX/lib/cn/runtime/include build/driv
 echo "Linking..."
 $CC driver.pp.exec.o $OPAM_SWITCH_PREFIX/lib/cn/runtime/libcn_exec.a -L $OPAM_SWITCH_PREFIX/lib/cn/runtime -lcn_exec -o driver.exe
 echo "Running..."
-./driver.exe
+for i in $(seq 1 10);
+do
+    gtime -f ~%e~%M ./driver.exe
+done
 echo "Done!"


### PR DESCRIPTION
Separate ownership from logical assertion for `ByteV` and usages